### PR TITLE
feat(replication): Add replication-group-sync for replication

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -193,6 +193,21 @@ replication-connect-timeout-ms 3100
 # future 'clusterx setnodes' commands because the replication thread is blocked on recv.
 replication-recv-timeout-ms 3200
 
+# Ignoed when rocksdb.write_options.sync is no.
+# When rocksdb.write_options.sync is yes, the replica will:
+# 1) Pull the latest changes from master
+# 2) Write the changes to replica's local storage. Each write would be called with rocksdb.write_options.sync = true. And the write would be synced to disk.
+# 3) Send acknowledgment to the master
+# If replication-group-sync is enabled, the replica will:
+# 1) Pull the latest changes from master
+# 2) Write the changes to replica's local storage. Each write would be called withrocksdb.write_options.sync = false
+# 3) Sync the changes to disk once.
+# 4) Send acknowledgment to the master
+# This option should provide better replication throughput when rocksdb.write_options.sync is true.
+# It would still guarantee replica would not lose any data with machine failure once it has acked the change.
+# Default: no
+replication-group-sync no
+
 # Maximum bytes to buffer before sending replication data to replicas.
 # The master will pack multiple write batches into one bulk to reduce network overhead,
 # but will send immediately if the bulk size exceeds this limit.

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -399,6 +399,10 @@ ReplicationThread::ReplicationThread(std::string host, uint32_t port, Server *sr
       srv_(srv),
       storage_(srv->storage),
       repl_state_(kReplConnecting),
+      // replication_group_sync_ is only enabled when both replication-group-sync and rocksdb.write_options.sync are
+      // true
+      replication_group_sync_(srv->GetConfig()->replication_group_sync &&
+                              srv->GetConfig()->rocks_db.write_options.sync),
       psync_steps_(
           this,
           CallbacksStateMachine::CallbackList{
@@ -636,6 +640,14 @@ void ReplicationThread::sendReplConfAck(bufferevent *bev, bool force) {
 
   // If force is true, always send ack. Otherwise, check if it has been 1s from last ack
   if (force || (now - last_ack_time_secs_) >= 1) {
+    if (replication_group_sync_) {
+      auto s = storage_->SyncWAL();
+      if (!s.IsOK()) {
+        error("[replication] Failed to sync WAL before ack: {}", s.Msg());
+        return;
+      }
+    }
+
     SendString(bev, redis::ArrayOfBulkStrings({"replconf", "ack", std::to_string(storage_->LatestSeqNumber())}));
     last_ack_time_secs_ = now;
   }
@@ -646,6 +658,12 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
   auto input = bufferevent_get_input(bev);
   bool data_written = false;
   bool force_ack = false;
+  // Use replication-group-sync logic if enabled and rocksdb.write_options.sync is true
+  rocksdb::WriteOptions write_opts = storage_->DefaultWriteOptions();
+  if (replication_group_sync_) {
+    write_opts.sync = false;
+  }
+
   while (true) {
     switch (incr_state_) {
       case Incr_batch_size: {
@@ -698,7 +716,7 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
 
         rocksdb::WriteBatch batch(std::move(bulk_string));
 
-        auto s = storage_->ReplicaApplyWriteBatch(&batch);
+        auto s = storage_->ReplicaApplyWriteBatch(&batch, write_opts);
         if (!s.IsOK()) {
           error("[replication] CRITICAL - Failed to write batch to local, {}. batch: 0x{}", s.Msg(),
                 util::StringToHex(batch.Data()));

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -162,6 +162,16 @@ void FeedSlaveThread::readCallback(bufferevent *bev, [[maybe_unused]] void *ctx)
   }
 }
 
+bool FeedSlaveThread::shouldSendGetAck(rocksdb::SequenceNumber seq) {
+  rocksdb::SequenceNumber largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(seq);
+  if (largest_unblockable_seq > last_getack_seq_) {
+    last_getack_seq_ = largest_unblockable_seq;
+    return true;
+  }
+
+  return false;
+}
+
 void FeedSlaveThread::loop() {
   // is_first_repl_batch was used to fix that replication may be stuck in a dead loop
   // when some seqs might be lost in the middle of the WAL log, so forced to replicate
@@ -204,6 +214,10 @@ void FeedSlaveThread::loop() {
     //    kMaxDelayUpdates than latest sequence.
     if (is_first_repl_batch || batches_bulk.size() >= max_delay_bytes_ || updates_in_batches >= max_delay_updates_ ||
         srv_->storage->LatestSeqNumber() - batch.sequence <= max_delay_updates_) {
+      if (shouldSendGetAck(batch.sequence)) {
+        batches_bulk += redis::BulkString("_getack");
+      }
+
       // Send entire bulk which contain multiple batches
       auto s = util::SockSend(conn_->GetFD(), batches_bulk, conn_->GetBufferEvent());
       if (!s.IsOK()) {
@@ -211,6 +225,7 @@ void FeedSlaveThread::loop() {
         Stop();
         return;
       }
+
       is_first_repl_batch = false;
       batches_bulk.clear();
       if (batches_bulk.capacity() > max_delay_bytes_ * 2) batches_bulk.shrink_to_fit();
@@ -616,14 +631,21 @@ ReplicationThread::CBState ReplicationThread::tryPSyncReadCB(bufferevent *bev) {
   }
 }
 
-void ReplicationThread::sendReplConfAck(bufferevent *bev) {
-  SendString(bev, redis::ArrayOfBulkStrings({"replconf", "ack", std::to_string(storage_->LatestSeqNumber())}));
+void ReplicationThread::sendReplConfAck(bufferevent *bev, bool force) {
+  int64_t now = util::GetTimeStamp();
+
+  // If force is true, always send ack. Otherwise, check if it has been 1s from last ack
+  if (force || (now - last_ack_time_secs_) >= 1) {
+    SendString(bev, redis::ArrayOfBulkStrings({"replconf", "ack", std::to_string(storage_->LatestSeqNumber())}));
+    last_ack_time_secs_ = now;
+  }
 }
 
 ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *bev) {
   repl_state_.store(kReplConnected, std::memory_order_relaxed);
   auto input = bufferevent_get_input(bev);
   bool data_written = false;
+  bool force_ack = false;
   while (true) {
     switch (incr_state_) {
       case Incr_batch_size: {
@@ -631,7 +653,7 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
         UniqueEvbufReadln line(input, EVBUFFER_EOL_CRLF_STRICT);
         if (!line) {
           if (data_written) {
-            sendReplConfAck(bev);
+            sendReplConfAck(bev, force_ack);
           }
           return CBState::AGAIN;
         }
@@ -647,7 +669,7 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
         // Read bulk data (batch data)
         if (incr_bulk_len_ + 2 > evbuffer_get_length(input)) {  // If data not enough
           if (data_written) {
-            sendReplConfAck(bev);
+            sendReplConfAck(bev, force_ack);
           }
           return CBState::AGAIN;
         }
@@ -662,9 +684,16 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
           // master would send the ping heartbeat packet to check whether the slave was alive or not,
           // don't write ping to db here.
           if (data_written) {
-            sendReplConfAck(bev);
+            sendReplConfAck(bev, force_ack);
           }
           return CBState::AGAIN;
+        }
+
+        if (bulk_string == "_getack") {
+          // master would send the _getack command to the master to get acknowledgment
+          // don't write _getack to db here.
+          force_ack = true;
+          continue;
         }
 
         rocksdb::WriteBatch batch(std::move(bulk_string));

--- a/src/cluster/replication.h
+++ b/src/cluster/replication.h
@@ -163,6 +163,7 @@ class ReplicationThread : private EventCallbackBase<ReplicationThread> {
   Server *srv_ = nullptr;
   engine::Storage *storage_ = nullptr;
   std::atomic<ReplState> repl_state_;
+  const bool replication_group_sync_ = false;
   std::atomic<int64_t> last_io_time_secs_ = 0;
   int64_t last_ack_time_secs_ = 0;
   bool next_try_old_psync_ = false;

--- a/src/cluster/replication.h
+++ b/src/cluster/replication.h
@@ -85,6 +85,8 @@ class FeedSlaveThread {
   // used to parse the ack response from the slave
   redis::Request req_;
   std::atomic<rocksdb::SequenceNumber> ack_seq_ = 0;
+  rocksdb::SequenceNumber last_getack_seq_ = 0;
+  int64_t last_ack_time_secs_ = 0;
 
   // Configurable delay limits
   size_t max_delay_bytes_;
@@ -94,6 +96,7 @@ class FeedSlaveThread {
   void checkLivenessIfNeed();
   void readCallback(bufferevent *bev, void *ctx);
   static void staticReadCallback(bufferevent *bev, void *ctx);
+  bool shouldSendGetAck(rocksdb::SequenceNumber seq);
 };
 
 class ReplicationThread : private EventCallbackBase<ReplicationThread> {
@@ -161,6 +164,7 @@ class ReplicationThread : private EventCallbackBase<ReplicationThread> {
   engine::Storage *storage_ = nullptr;
   std::atomic<ReplState> repl_state_;
   std::atomic<int64_t> last_io_time_secs_ = 0;
+  int64_t last_ack_time_secs_ = 0;
   bool next_try_old_psync_ = false;
   bool next_try_without_announce_ip_address_ = false;
 
@@ -202,8 +206,6 @@ class ReplicationThread : private EventCallbackBase<ReplicationThread> {
   CBState fullSyncWriteCB(bufferevent *bev);
   CBState fullSyncReadCB(bufferevent *bev);
 
-  void sendReplConfAck(bufferevent *bev);
-
   Status sendAuth(int sock_fd, ssl_st *ssl);
   Status fetchFile(int sock_fd, evbuffer *evbuf, const std::string &dir, const std::string &file, uint32_t crc,
                    const FetchFileCallback &fn, ssl_st *ssl);
@@ -213,6 +215,8 @@ class ReplicationThread : private EventCallbackBase<ReplicationThread> {
   static bool isRestoringError(std::string_view err);
   static bool isWrongPsyncNum(std::string_view err);
   static bool isUnknownOption(std::string_view err);
+
+  void sendReplConfAck(bufferevent *bev, bool force = false);
 
   Status parseWriteBatch(const rocksdb::WriteBatch &write_batch);
 };

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -102,12 +102,22 @@ class CommandNamespace : public Commander {
       Status s = srv->GetNamespace()->Del(args_[2]);
       *output = s.IsOK() ? redis::RESP_OK : redis::Error(s);
       warn("Deleted namespace: {}, addr: {}, result: {}", args_[2], conn->GetAddr(), s.Msg());
+    } else if (args_.size() == 2 && sub_command == "current") {
+      *output = redis::BulkString(conn->GetNamespace());
     } else {
-      return {Status::RedisExecErr, "NAMESPACE subcommand must be one of GET, SET, DEL, ADD"};
+      return {Status::RedisExecErr, "NAMESPACE subcommand must be one of GET, SET, DEL, ADD and CURRENT"};
     }
     return Status::OK();
   }
 };
+
+static uint64_t GenerateNamespaceFlag(uint64_t flags, const std::vector<std::string> &args) {
+  if (args.size() >= 2 && util::EqualICase(args[1], "current")) {
+    return flags & ~kCmdAdmin;
+  }
+
+  return flags;
+}
 
 class CommandKeys : public Commander {
  public:
@@ -1539,49 +1549,48 @@ class CommandFlushBlockCache : public Commander {
   }
 };
 
-REDIS_REGISTER_COMMANDS(Server, MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loading auth", NO_KEY),
-                        MakeCmdAttr<CommandPing>("ping", -1, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandSelect>("select", 2, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandInfo>("info", -1, "read-only ok-loading", NO_KEY),
-                        MakeCmdAttr<CommandRole>("role", 1, "read-only ok-loading", NO_KEY),
-                        MakeCmdAttr<CommandConfig>("config", -2, "read-only admin", NO_KEY, GenerateConfigFlag),
-                        MakeCmdAttr<CommandNamespace>("namespace", -3, "read-only admin", NO_KEY),
-                        MakeCmdAttr<CommandKeys>("keys", 2, "read-only slow", NO_KEY),
-                        MakeCmdAttr<CommandFlushDB>("flushdb", 1, "write no-dbsize-check exclusive", NO_KEY),
-                        MakeCmdAttr<CommandFlushAll>("flushall", 1, "write no-dbsize-check exclusive admin", NO_KEY),
-                        MakeCmdAttr<CommandDBSize>("dbsize", -1, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandSlowlog>("slowlog", -2, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandKProfile>("kprofile", -3, "read-only admin", NO_KEY),
-                        MakeCmdAttr<CommandPerfLog>("perflog", -2, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandClient>("client", -2, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandMonitor>("monitor", 1, "read-only no-multi no-script", NO_KEY),
-                        MakeCmdAttr<CommandShutdown>("shutdown", 1, "read-only exclusive no-multi no-script admin",
-                                                     NO_KEY),
-                        MakeCmdAttr<CommandQuit>("quit", 1, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandScan>("scan", -2, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandRandomKey>("randomkey", 1, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandDebug>("debug", -2, "read-only exclusive", NO_KEY, CommandDebug::FlagGen),
-                        MakeCmdAttr<CommandCommand>("command", -1, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandEcho>("echo", 2, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandTime>("time", 1, "read-only ok-loading", NO_KEY),
-                        MakeCmdAttr<CommandDisk>("disk", 3, "read-only", 2, 2, 1),
-                        MakeCmdAttr<CommandMemory>("memory", 3, "read-only", 2, 2, 1),
-                        MakeCmdAttr<CommandHello>("hello", -1, "read-only ok-loading auth", NO_KEY),
-                        MakeCmdAttr<CommandRestore>("restore", -4, "write", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(
+    Server, MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loading auth", NO_KEY),
+    MakeCmdAttr<CommandPing>("ping", -1, "read-only", NO_KEY),
+    MakeCmdAttr<CommandSelect>("select", 2, "read-only", NO_KEY),
+    MakeCmdAttr<CommandInfo>("info", -1, "read-only ok-loading", NO_KEY),
+    MakeCmdAttr<CommandRole>("role", 1, "read-only ok-loading", NO_KEY),
+    MakeCmdAttr<CommandConfig>("config", -2, "read-only admin", NO_KEY, GenerateConfigFlag),
+    MakeCmdAttr<CommandNamespace>("namespace", -2, "read-only admin", NO_KEY, GenerateNamespaceFlag),
+    MakeCmdAttr<CommandKeys>("keys", 2, "read-only slow", NO_KEY),
+    MakeCmdAttr<CommandFlushDB>("flushdb", 1, "write no-dbsize-check exclusive", NO_KEY),
+    MakeCmdAttr<CommandFlushAll>("flushall", 1, "write no-dbsize-check exclusive admin", NO_KEY),
+    MakeCmdAttr<CommandDBSize>("dbsize", -1, "read-only", NO_KEY),
+    MakeCmdAttr<CommandSlowlog>("slowlog", -2, "read-only", NO_KEY),
+    MakeCmdAttr<CommandKProfile>("kprofile", -3, "read-only admin", NO_KEY),
+    MakeCmdAttr<CommandPerfLog>("perflog", -2, "read-only", NO_KEY),
+    MakeCmdAttr<CommandClient>("client", -2, "read-only", NO_KEY),
+    MakeCmdAttr<CommandMonitor>("monitor", 1, "read-only no-multi no-script", NO_KEY),
+    MakeCmdAttr<CommandShutdown>("shutdown", 1, "read-only exclusive no-multi no-script admin", NO_KEY),
+    MakeCmdAttr<CommandQuit>("quit", 1, "read-only", NO_KEY), MakeCmdAttr<CommandScan>("scan", -2, "read-only", NO_KEY),
+    MakeCmdAttr<CommandRandomKey>("randomkey", 1, "read-only", NO_KEY),
+    MakeCmdAttr<CommandDebug>("debug", -2, "read-only exclusive", NO_KEY, CommandDebug::FlagGen),
+    MakeCmdAttr<CommandCommand>("command", -1, "read-only", NO_KEY),
+    MakeCmdAttr<CommandEcho>("echo", 2, "read-only", NO_KEY),
+    MakeCmdAttr<CommandTime>("time", 1, "read-only ok-loading", NO_KEY),
+    MakeCmdAttr<CommandDisk>("disk", 3, "read-only", 2, 2, 1),
+    MakeCmdAttr<CommandMemory>("memory", 3, "read-only", 2, 2, 1),
+    MakeCmdAttr<CommandHello>("hello", -1, "read-only ok-loading auth", NO_KEY),
+    MakeCmdAttr<CommandRestore>("restore", -4, "write", 1, 1, 1),
 
-                        MakeCmdAttr<CommandCompact>("compact", 1, "read-only no-script", NO_KEY),
-                        MakeCmdAttr<CommandBGSave>("bgsave", 1, "read-only no-script admin", NO_KEY),
-                        MakeCmdAttr<CommandLastSave>("lastsave", -1, "read-only admin", NO_KEY),
-                        MakeCmdAttr<CommandFlushBackup>("flushbackup", 1, "read-only no-script admin", NO_KEY),
-                        MakeCmdAttr<CommandSlaveOf>("slaveof", 3, "read-only exclusive no-script admin", NO_KEY),
-                        MakeCmdAttr<CommandSlaveOf>("replicaof", 3, "read-only exclusive no-script admin", NO_KEY),
-                        MakeCmdAttr<CommandStats>("stats", 1, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandRdb>("rdb", -3, "write exclusive admin", NO_KEY),
-                        MakeCmdAttr<CommandReset>("reset", 1, "ok-loading bypass-multi no-script", NO_KEY),
-                        MakeCmdAttr<CommandApplyBatch>("applybatch", -2, "write no-multi", NO_KEY),
-                        MakeCmdAttr<CommandDump>("dump", 2, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandPollUpdates>("pollupdates", -2, "read-only admin", NO_KEY),
-                        MakeCmdAttr<CommandSST>("sst", -3, "write exclusive admin", 1, 1, 1),
-                        MakeCmdAttr<CommandFlushMemTable>("flushmemtable", -1, "exclusive write", NO_KEY),
-                        MakeCmdAttr<CommandFlushBlockCache>("flushblockcache", 1, "exclusive write", NO_KEY), )
+    MakeCmdAttr<CommandCompact>("compact", 1, "read-only no-script", NO_KEY),
+    MakeCmdAttr<CommandBGSave>("bgsave", 1, "read-only no-script admin", NO_KEY),
+    MakeCmdAttr<CommandLastSave>("lastsave", -1, "read-only admin", NO_KEY),
+    MakeCmdAttr<CommandFlushBackup>("flushbackup", 1, "read-only no-script admin", NO_KEY),
+    MakeCmdAttr<CommandSlaveOf>("slaveof", 3, "read-only exclusive no-script admin", NO_KEY),
+    MakeCmdAttr<CommandSlaveOf>("replicaof", 3, "read-only exclusive no-script admin", NO_KEY),
+    MakeCmdAttr<CommandStats>("stats", 1, "read-only", NO_KEY),
+    MakeCmdAttr<CommandRdb>("rdb", -3, "write exclusive admin", NO_KEY),
+    MakeCmdAttr<CommandReset>("reset", 1, "ok-loading bypass-multi no-script", NO_KEY),
+    MakeCmdAttr<CommandApplyBatch>("applybatch", -2, "write no-multi", NO_KEY),
+    MakeCmdAttr<CommandDump>("dump", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandPollUpdates>("pollupdates", -2, "read-only admin", NO_KEY),
+    MakeCmdAttr<CommandSST>("sst", -3, "write exclusive admin", 1, 1, 1),
+    MakeCmdAttr<CommandFlushMemTable>("flushmemtable", -1, "exclusive write", NO_KEY),
+    MakeCmdAttr<CommandFlushBlockCache>("flushblockcache", 1, "exclusive write", NO_KEY), )
 }  // namespace redis

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -203,6 +203,7 @@ Config::Config() {
       {"slave-read-only", false, new YesNoField(&slave_readonly, true)},
       {"replication-connect-timeout-ms", false, new IntField(&replication_connect_timeout_ms, 3100, 0, INT_MAX)},
       {"replication-recv-timeout-ms", false, new IntField(&replication_recv_timeout_ms, 3200, 0, INT_MAX)},
+      {"replication-group-sync", false, new YesNoField(&replication_group_sync, false)},
       {"replication-delay-bytes", false, new IntField(&max_replication_delay_bytes, 16 * 1024, 1, INT_MAX)},
       {"replication-delay-updates", false, new IntField(&max_replication_delay_updates, 16, 1, INT_MAX)},
       {"use-rsid-psync", true, new YesNoField(&use_rsid_psync, false)},

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -132,6 +132,7 @@ struct Config {
   bool auto_resize_block_and_sst = true;
   int fullsync_recv_file_delay = 0;
   bool use_rsid_psync = false;
+  bool replication_group_sync = false;
   std::vector<std::string> binds;
   std::string dir;
   std::string db_dir;

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -704,34 +704,32 @@ void Server::OnEntryAddedToStream(const std::string &ns, const std::string &key,
 void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, uint64_t num_replicas) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
 
-  wait_contexts_.emplace_back(conn, target_seq, num_replicas);
+  wait_contexts_.emplace(target_seq, WaitContext(conn, target_seq, num_replicas));
   IncrBlockedClientNum();
 }
 
 void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
 
-  for (auto it = wait_contexts_.begin(); it != wait_contexts_.end();) {
-    // Check if target sequence is reached
-    if (seq >= it->target_seq) {
-      // Count how many replicas have reached the target sequence
-      size_t reached_replicas = GetReplicasReachedSequence(it->target_seq);
+  // find the last entry with target_seq > seq, which cannot wakeup
+  auto end_it = wait_contexts_.upper_bound(seq);
+  for (auto it = wait_contexts_.begin(); it != end_it;) {
+    // Count how many replicas have reached the target sequence
+    size_t reached_replicas = GetReplicasReachedSequence(it->second.target_seq);
 
-      // If enough replicas have reached the target sequence, wake up the connection
-      if (reached_replicas >= it->num_replicas) {
-        // Send the response with the number of replicas that have reached the target sequence
-        it->conn->Reply(redis::Integer(reached_replicas));
+    // If enough replicas have reached the target sequence, wake up the connection
+    if (reached_replicas >= it->second.num_replicas) {
+      // Send the response with the number of replicas that have reached the target sequence
+      it->second.conn->Reply(redis::Integer(reached_replicas));
 
-        auto s = it->conn->Owner()->EnableWriteEvent(it->conn->GetFD());
-        if (!s.IsOK()) {
-          error("[server] Failed to enable write event on WAIT connection {}: {}", it->conn->GetFD(), s.Msg());
-        }
-        it = wait_contexts_.erase(it);
-        DecrBlockedClientNum();
-        continue;
+      auto s = it->second.conn->Owner()->EnableWriteEvent(it->second.conn->GetFD());
+      if (!s.IsOK()) {
+        error("[server] Failed to enable write event on WAIT connection {}: {}", it->second.conn->GetFD(), s.Msg());
       }
+      it = wait_contexts_.erase(it);
+      DecrBlockedClientNum();
+      continue;
     }
-
     ++it;
   }
 }
@@ -740,7 +738,7 @@ void Server::CleanupWaitConnection(redis::Connection *conn) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
 
   auto it = std::find_if(wait_contexts_.begin(), wait_contexts_.end(),
-                         [conn](const auto &context) { return context.conn == conn; });
+                         [conn](const auto &pair) { return pair.second.conn == conn; });
   if (it != wait_contexts_.end()) {
     wait_contexts_.erase(it);
     DecrBlockedClientNum();
@@ -756,6 +754,28 @@ size_t Server::GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq) {
     }
   }
   return reached_replicas;
+}
+
+rocksdb::SequenceNumber Server::LargestTargetSeqToWakeup(rocksdb::SequenceNumber seq) {
+  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
+  if (wait_contexts_.empty()) {
+    return 0;
+  }
+
+  // Use upper_bound to find the first entry with target_seq > seq
+  // the largest seq that can wakeup is the last element before it
+  auto it = wait_contexts_.upper_bound(seq);
+
+  // when wait_contexts_ is empty, it == wait_contexts_.begin().
+  // when all wait_contexts_.target_seq > seq, it == wait_contexts_.begin().
+  // both cases should return 0.
+  if (it == wait_contexts_.begin()) {
+    return 0;
+  }
+
+  // Return the largest target_seq that could potentially be unblocked
+  auto last_it = std::prev(it);
+  return last_it->second.target_seq;
 }
 
 void Server::updateCachedTime() { unix_time_secs.store(util::GetTimeStamp()); }

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -237,6 +237,9 @@ class Server {
 
   // Helper methods for WAIT command
   size_t GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq);
+  // Return the largest wait_context.target_seq that can wakeup given the seq.
+  // If no wait_context can wakeup, return 0.
+  rocksdb::SequenceNumber LargestTargetSeqToWakeup(rocksdb::SequenceNumber seq);
 
   size_t GetReplicaCount() {
     slave_threads_mu_.lock();
@@ -422,7 +425,7 @@ class Server {
     WaitContext(redis::Connection *c, rocksdb::SequenceNumber seq, uint64_t replicas)
         : conn(c), target_seq(seq), num_replicas(replicas) {}
   };
-  std::list<WaitContext> wait_contexts_;
+  std::multimap<rocksdb::SequenceNumber, WaitContext> wait_contexts_;
   std::mutex wait_contexts_mu_;
 
   // threads

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -845,8 +845,8 @@ rocksdb::Status Storage::ingestSST(rocksdb::ColumnFamilyHandle *cf_handle,
 
 void Storage::FlushBlockCache() { shared_block_cache_->EraseUnRefEntries(); }
 
-Status Storage::ReplicaApplyWriteBatch(rocksdb::WriteBatch *batch) {
-  return applyWriteBatch(default_write_opts_, batch);
+Status Storage::ReplicaApplyWriteBatch(rocksdb::WriteBatch *batch, const rocksdb::WriteOptions &options) {
+  return applyWriteBatch(options, batch);
 }
 
 Status Storage::applyWriteBatch(const rocksdb::WriteOptions &options, rocksdb::WriteBatch *batch) {
@@ -863,6 +863,14 @@ Status Storage::applyWriteBatch(const rocksdb::WriteOptions &options, rocksdb::W
 Status Storage::ApplyWriteBatch(const rocksdb::WriteOptions &options, std::string &&raw_batch) {
   auto batch = rocksdb::WriteBatch(std::move(raw_batch));
   return applyWriteBatch(options, &batch);
+}
+
+Status Storage::SyncWAL() {
+  auto s = db_->SyncWAL();
+  if (!s.ok()) {
+    return {Status::NotOK, s.ToString()};
+  }
+  return Status::OK();
 }
 
 void Storage::RecordStat(StatType type, uint64_t v) {

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -233,9 +233,10 @@ class Storage {
   Status RestoreFromBackup();
   Status RestoreFromCheckpoint();
   Status GetWALIter(rocksdb::SequenceNumber seq, std::unique_ptr<rocksdb::TransactionLogIterator> *iter);
-  Status ReplicaApplyWriteBatch(rocksdb::WriteBatch *batch);
+  Status ReplicaApplyWriteBatch(rocksdb::WriteBatch *batch, const rocksdb::WriteOptions &options);
   Status ApplyWriteBatch(const rocksdb::WriteOptions &options, std::string &&raw_batch);
   rocksdb::SequenceNumber LatestSeqNumber();
+  Status SyncWAL();
 
   [[nodiscard]] rocksdb::Status Get(engine::Context &ctx, const rocksdb::ReadOptions &options,
                                     const rocksdb::Slice &key, std::string *value);

--- a/tests/cppunit/server_wait_test.cc
+++ b/tests/cppunit/server_wait_test.cc
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "server/server.h"
+#include "test_base.h"
+
+class ServerWaitTest : public TestBase {
+ protected:
+  void SetUp() override {
+    // Create server
+    server_ = std::make_unique<Server>(storage_.get(), storage_->GetConfig());
+    // we don't need the server resource, so just stop it once it's started
+    server_->Stop();
+    server_->Join();
+  }
+
+  ~ServerWaitTest() override = default;
+
+  // Helper method to add wait contexts for testing using the public API
+  void addWaitContext(rocksdb::SequenceNumber target_seq, uint64_t num_replicas) {
+    // Use the public BlockOnWait method to add wait contexts
+    server_->BlockOnWait(nullptr, target_seq, num_replicas);
+  }
+
+  std::unique_ptr<Server> server_;
+};
+
+TEST_F(ServerWaitTest, EmptyMap) {
+  // Test with empty wait_contexts_ map
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 0) << "Should return 0 for empty map";
+}
+
+TEST_F(ServerWaitTest, AllTargetSeqsGreaterThanSeq) {
+  // Add wait contexts with target_seq > 100
+  addWaitContext(150, 1);
+  addWaitContext(200, 1);
+  addWaitContext(250, 1);
+
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 0) << "Should return 0 when all target_seqs > seq";
+}
+
+TEST_F(ServerWaitTest, SingleTargetSeqLessThanSeq) {
+  // Add a single wait context with target_seq < 100
+  addWaitContext(50, 1);
+
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 50) << "Should return the target_seq when it's <= seq";
+}
+
+TEST_F(ServerWaitTest, MultipleTargetSeqsLessThanSeq) {
+  // Add multiple wait contexts with target_seq < 100
+  addWaitContext(30, 1);
+  addWaitContext(50, 1);
+  addWaitContext(80, 1);
+
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 80) << "Should return the largest target_seq <= seq";
+}
+
+TEST_F(ServerWaitTest, MixedTargetSeqs) {
+  // Add wait contexts with mixed target_seqs
+  addWaitContext(30, 1);   // < 100
+  addWaitContext(50, 1);   // < 100
+  addWaitContext(80, 1);   // < 100
+  addWaitContext(120, 1);  // > 100
+  addWaitContext(150, 1);  // > 100
+
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 80) << "Should return the largest target_seq <= seq";
+}
+
+TEST_F(ServerWaitTest, ExactMatch) {
+  // Add wait context with target_seq exactly equal to seq
+  addWaitContext(100, 1);
+
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 100) << "Should return target_seq when it equals seq";
+}
+
+TEST_F(ServerWaitTest, MultipleExactMatches) {
+  // Add multiple wait contexts with the same target_seq
+  addWaitContext(100, 1);
+  addWaitContext(100, 2);  // Same target_seq, different num_replicas
+  addWaitContext(150, 1);  // > 100
+
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 100) << "Should return target_seq for exact match";
+}
+
+TEST_F(ServerWaitTest, BoundaryConditions) {
+  // Test boundary conditions
+  addWaitContext(1, 1);
+  addWaitContext(99, 1);
+  addWaitContext(100, 1);
+  addWaitContext(101, 1);
+
+  // Test with seq = 0
+  auto result1 = server_->LargestTargetSeqToWakeup(0);
+  EXPECT_EQ(result1, 0) << "Should return 0 when seq = 0";
+
+  // Test with seq = 1
+  auto result2 = server_->LargestTargetSeqToWakeup(1);
+  EXPECT_EQ(result2, 1) << "Should return 1 when seq = 1";
+
+  // Test with seq = 100
+  auto result3 = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result3, 100) << "Should return 100 for exact match";
+
+  // Test with seq = 99
+  auto result4 = server_->LargestTargetSeqToWakeup(99);
+  EXPECT_EQ(result4, 99) << "Should return 99 for exact match";
+}
+
+TEST_F(ServerWaitTest, LargeSequenceNumbers) {
+  // Test with large sequence numbers
+  addWaitContext(1000000, 1);
+  addWaitContext(2000000, 1);
+  addWaitContext(3000000, 1);
+
+  auto result = server_->LargestTargetSeqToWakeup(2500000);
+  EXPECT_EQ(result, 2000000) << "Should work with large sequence numbers";
+}

--- a/tests/gocase/integration/replication/replication_test.go
+++ b/tests/gocase/integration/replication/replication_test.go
@@ -622,3 +622,49 @@ func TestSlaveLostMaster(t *testing.T) {
 	duration := time.Since(start)
 	require.Less(t, duration, time.Second*6)
 }
+
+func TestReplicationGroupSyncConfig(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	master := util.StartServer(t, map[string]string{})
+	defer master.Close()
+	masterClient := master.NewClient()
+	defer func() { require.NoError(t, masterClient.Close()) }()
+
+	slave := util.StartServer(t, map[string]string{
+		"replication-group-sync":     "yes",
+		"rocksdb.write_options.sync": "yes",
+	})
+	defer slave.Close()
+	slaveClient := slave.NewClient()
+	defer func() { require.NoError(t, slaveClient.Close()) }()
+
+	t.Run("Replication should work with replication-group-sync enabled", func(t *testing.T) {
+		util.SlaveOf(t, slaveClient, master)
+		util.WaitForSync(t, slaveClient)
+		require.Equal(t, "slave", util.FindInfoEntry(slaveClient, "role"))
+
+		require.NoError(t, masterClient.Set(ctx, "key1", "value1", 0).Err())
+		util.WaitForOffsetSync(t, masterClient, slaveClient, 5*time.Second)
+		require.Equal(t, "value1", slaveClient.Get(ctx, "key1").Val())
+	})
+
+	// Test with replication-group-sync disabled
+	slave2 := util.StartServer(t, map[string]string{
+		"replication-group-sync": "no",
+	})
+	defer slave2.Close()
+	slaveClient2 := slave2.NewClient()
+	defer func() { require.NoError(t, slaveClient2.Close()) }()
+
+	t.Run("Replication should work with replication-group-sync disabled", func(t *testing.T) {
+		util.SlaveOf(t, slaveClient2, master)
+		util.WaitForSync(t, slaveClient2)
+		require.Equal(t, "slave", util.FindInfoEntry(slaveClient2, "role"))
+
+		require.NoError(t, masterClient.Set(ctx, "key2", "value2", 0).Err())
+		util.WaitForOffsetSync(t, masterClient, slaveClient2, 5*time.Second)
+		require.Equal(t, "value2", slaveClient2.Get(ctx, "key2").Val())
+	})
+}


### PR DESCRIPTION
When I load test https://github.com/apache/kvrocks/pull/3075 with `rocksdb.write_options.sync yes`, I notice the replication thread becomes the bottleneck because it is single thread and need to sync for every write.

With `replication-group-sync` on, the replication would instead sync WAL once before ack. This increases the throughput of replication by 6% to 10% when I call WAIT after each SET.

